### PR TITLE
fix: use own code to publish to Hex

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,4 +21,4 @@ jobs:
         id: release
         run: gh release create $(cat version.txt) --generate-notes --target main
       - name: Publish package to Hex.pm
-        uses: wesleimp/action-publish-hex@v1
+        uses: ./scripts/publish.sh

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,7 @@
+#/bin/bash
+
+docker run --rm elixir:1.16.0-alpine \
+    -v ${PWD}:/local \
+    -w /local \
+    -e HEX_API_KEY \
+    /local/scripts/publish_script.sh

--- a/scripts/publish_script.sh
+++ b/scripts/publish_script.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Must be /bin/sh because this script is meant to be run in Alpine,
+# which uses busybox and doesn't have bash.
+
+if [[ -z "${HEX_API_KEY}" ]]; then
+	echo "HEX_API_KEY is not set" && exit 1
+fi
+
+echo "===> install hex"
+echo
+mix local.hex --force
+mix local.rebar --force
+
+echo "===> install dependencies"
+echo
+mix do deps.get, deps.compile
+
+echo "===> Build hex package"
+echo
+mix hex.build
+
+echo "===> Publishing hex package"
+echo
+mix hex.publish --yes


### PR DESCRIPTION
The only action I could find for this was outdated, and doesn't appear to be maintained anymore.