### PR TITLE
fix: pass secrets to shared workflows

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -7,3 +7,4 @@ on:
 jobs:
   generate:
     uses: nuonco/.github/.github/workflows/generate.yml@ja/3498-shared-sdk-workflows
+    secrets: inherit

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,3 +6,4 @@ on:
 jobs:
   check-pr:
     uses: nuonco/.github/.github/workflows/pull_request.yml@ja/3498-shared-sdk-workflows
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,3 +13,4 @@ env:
 jobs:
   release:
     uses: nuonco/.github/.github/workflows/release.yml@ja/3498-shared-sdk-workflows
+    secrets: inherit


### PR DESCRIPTION
Even though the secrets we're using here are all org secrets -- and therefor available to all repos -- no secrest are passed to shared workflows by default.